### PR TITLE
fix: Remove dark violet color for static fields

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -30,9 +30,6 @@ def main() -> None:
             "DIFF_ADDED_OPACITY": "40%" if kind == "Dark" else "20%",
             "DIFF_CONFLICT_OPACITY": "30%" if kind == "Dark" else "20%",
             "DIFF_DELETED_OPACITY": "20%" if kind == "Dark" else "10%",
-            "IDENTIFIER_FIELD": "Text" if kind == "Dark" else "DarkViolet",
-            "IDENTIFIER_FIELD_STATIC": "Teal" if kind == "Dark" else "DarkViolet",
-            "IDENTIFIER_FIELD_BOOLEAN": "false" if kind == "Dark" else "true",
             "TRANSPARENT": "ffffff" if kind == "Dark" else "000000",
         }
         with open(

--- a/generator/theme.template
+++ b/generator/theme.template
@@ -384,18 +384,11 @@
       "layer": 20
     },
     "identifier.field": {
-      "fgColor": "{{IDENTIFIER_FIELD}}",
-      "fontModifier": {
-        "bold": {{IDENTIFIER_FIELD_BOOLEAN}}
-      },
+      "fgColor": "Text",
       "layer": 20
     },
     "identifier.field.static": {
-      "fgColor": "{{IDENTIFIER_FIELD_STATIC}}",
-      "fontModifier": {
-        "bold": {{IDENTIFIER_FIELD_BOOLEAN}},
-        "italic": {{IDENTIFIER_FIELD_BOOLEAN}}
-      },
+      "fgColor": "Teal",
       "layer": 20
     },
     "identifier.function.call": {
@@ -765,7 +758,6 @@
     "Base": "{{BASE}}",
     "Blue": "{{BLUE}}",
     "Crust": "{{CRUST}}",
-    "DarkViolet": "660e7a",
     "Flamingo": "{{FLAMINGO}}",
     "Green": "{{GREEN}}",
     "Lavender": "{{LAVENDER}}",

--- a/themes/catppuccin-frappe.json
+++ b/themes/catppuccin-frappe.json
@@ -385,17 +385,10 @@
     },
     "identifier.field": {
       "fgColor": "Text",
-      "fontModifier": {
-        "bold": false
-      },
       "layer": 20
     },
     "identifier.field.static": {
       "fgColor": "Teal",
-      "fontModifier": {
-        "bold": false,
-        "italic": false
-      },
       "layer": 20
     },
     "identifier.function.call": {
@@ -765,7 +758,6 @@
     "Base": "303446",
     "Blue": "8caaee",
     "Crust": "232634",
-    "DarkViolet": "660e7a",
     "Flamingo": "eebebe",
     "Green": "a6d189",
     "Lavender": "babbf1",

--- a/themes/catppuccin-latte.json
+++ b/themes/catppuccin-latte.json
@@ -384,18 +384,11 @@
       "layer": 20
     },
     "identifier.field": {
-      "fgColor": "DarkViolet",
-      "fontModifier": {
-        "bold": true
-      },
+      "fgColor": "Text",
       "layer": 20
     },
     "identifier.field.static": {
-      "fgColor": "DarkViolet",
-      "fontModifier": {
-        "bold": true,
-        "italic": true
-      },
+      "fgColor": "Teal",
       "layer": 20
     },
     "identifier.function.call": {
@@ -765,7 +758,6 @@
     "Base": "eff1f5",
     "Blue": "1e66f5",
     "Crust": "dce0e8",
-    "DarkViolet": "660e7a",
     "Flamingo": "dd7878",
     "Green": "40a02b",
     "Lavender": "7287fd",

--- a/themes/catppuccin-macchiato.json
+++ b/themes/catppuccin-macchiato.json
@@ -385,17 +385,10 @@
     },
     "identifier.field": {
       "fgColor": "Text",
-      "fontModifier": {
-        "bold": false
-      },
       "layer": 20
     },
     "identifier.field.static": {
       "fgColor": "Teal",
-      "fontModifier": {
-        "bold": false,
-        "italic": false
-      },
       "layer": 20
     },
     "identifier.function.call": {
@@ -765,7 +758,6 @@
     "Base": "24273a",
     "Blue": "8aadf4",
     "Crust": "181926",
-    "DarkViolet": "660e7a",
     "Flamingo": "f0c6c6",
     "Green": "a6da95",
     "Lavender": "b7bdf8",

--- a/themes/catppuccin-mocha.json
+++ b/themes/catppuccin-mocha.json
@@ -385,17 +385,10 @@
     },
     "identifier.field": {
       "fgColor": "Text",
-      "fontModifier": {
-        "bold": false
-      },
       "layer": 20
     },
     "identifier.field.static": {
       "fgColor": "Teal",
-      "fontModifier": {
-        "bold": false,
-        "italic": false
-      },
       "layer": 20
     },
     "identifier.function.call": {
@@ -765,7 +758,6 @@
     "Base": "1e1e2e",
     "Blue": "89b4fa",
     "Crust": "11111b",
-    "DarkViolet": "660e7a",
     "Flamingo": "f2cdcd",
     "Green": "a6e3a1",
     "Lavender": "b4befe",


### PR DESCRIPTION
That color was initially there because of the JetBrains theme, though after discussing with @sgoudham it turned out to not be intended but rather a bug.