### PR TITLE
Add editor indent guide colors

### DIFF
--- a/generator/theme.template
+++ b/generator/theme.template
@@ -359,6 +359,24 @@
     "editor.text.scheme": {
       "fgColor": "Overlay2"
     },
+    "editor.indent.guide": {
+        "fgColor": "Overlay0",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.current": {
+        "fgColor": "Overlay2",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.declaration": {
+        "fgColor": "Surface0"
+    },
+    "editor.indent.guide.declaration.current": {
+        "fgColor": "Overlay0"
+    },
     "entityReference.html": {
       "fgColor": "Red",
       "layer": 20

--- a/generator/theme.template
+++ b/generator/theme.template
@@ -360,22 +360,22 @@
       "fgColor": "Overlay2"
     },
     "editor.indent.guide": {
-        "fgColor": "Overlay0",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay0",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.current": {
-        "fgColor": "Overlay2",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay2",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.declaration": {
-        "fgColor": "Surface0"
+      "fgColor": "Surface0"
     },
     "editor.indent.guide.declaration.current": {
-        "fgColor": "Overlay0"
+      "fgColor": "Overlay0"
     },
     "entityReference.html": {
       "fgColor": "Red",

--- a/themes/catppuccin-frappe.json
+++ b/themes/catppuccin-frappe.json
@@ -359,6 +359,24 @@
     "editor.text.scheme": {
       "fgColor": "Overlay2"
     },
+    "editor.indent.guide": {
+        "fgColor": "Overlay0",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.current": {
+        "fgColor": "Overlay2",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.declaration": {
+        "fgColor": "Surface0"
+    },
+    "editor.indent.guide.declaration.current": {
+        "fgColor": "Overlay0"
+    },
     "entityReference.html": {
       "fgColor": "Red",
       "layer": 20

--- a/themes/catppuccin-frappe.json
+++ b/themes/catppuccin-frappe.json
@@ -360,22 +360,22 @@
       "fgColor": "Overlay2"
     },
     "editor.indent.guide": {
-        "fgColor": "Overlay0",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay0",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.current": {
-        "fgColor": "Overlay2",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay2",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.declaration": {
-        "fgColor": "Surface0"
+      "fgColor": "Surface0"
     },
     "editor.indent.guide.declaration.current": {
-        "fgColor": "Overlay0"
+      "fgColor": "Overlay0"
     },
     "entityReference.html": {
       "fgColor": "Red",

--- a/themes/catppuccin-latte.json
+++ b/themes/catppuccin-latte.json
@@ -359,6 +359,24 @@
     "editor.text.scheme": {
       "fgColor": "Overlay2"
     },
+    "editor.indent.guide": {
+        "fgColor": "Overlay0",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.current": {
+        "fgColor": "Overlay2",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.declaration": {
+        "fgColor": "Surface0"
+    },
+    "editor.indent.guide.declaration.current": {
+        "fgColor": "Overlay0"
+    },
     "entityReference.html": {
       "fgColor": "Red",
       "layer": 20

--- a/themes/catppuccin-latte.json
+++ b/themes/catppuccin-latte.json
@@ -360,22 +360,22 @@
       "fgColor": "Overlay2"
     },
     "editor.indent.guide": {
-        "fgColor": "Overlay0",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay0",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.current": {
-        "fgColor": "Overlay2",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay2",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.declaration": {
-        "fgColor": "Surface0"
+      "fgColor": "Surface0"
     },
     "editor.indent.guide.declaration.current": {
-        "fgColor": "Overlay0"
+      "fgColor": "Overlay0"
     },
     "entityReference.html": {
       "fgColor": "Red",

--- a/themes/catppuccin-macchiato.json
+++ b/themes/catppuccin-macchiato.json
@@ -359,6 +359,24 @@
     "editor.text.scheme": {
       "fgColor": "Overlay2"
     },
+    "editor.indent.guide": {
+        "fgColor": "Overlay0",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.current": {
+        "fgColor": "Overlay2",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.declaration": {
+        "fgColor": "Surface0"
+    },
+    "editor.indent.guide.declaration.current": {
+        "fgColor": "Overlay0"
+    },
     "entityReference.html": {
       "fgColor": "Red",
       "layer": 20

--- a/themes/catppuccin-macchiato.json
+++ b/themes/catppuccin-macchiato.json
@@ -360,22 +360,22 @@
       "fgColor": "Overlay2"
     },
     "editor.indent.guide": {
-        "fgColor": "Overlay0",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay0",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.current": {
-        "fgColor": "Overlay2",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay2",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.declaration": {
-        "fgColor": "Surface0"
+      "fgColor": "Surface0"
     },
     "editor.indent.guide.declaration.current": {
-        "fgColor": "Overlay0"
+      "fgColor": "Overlay0"
     },
     "entityReference.html": {
       "fgColor": "Red",

--- a/themes/catppuccin-mocha.json
+++ b/themes/catppuccin-mocha.json
@@ -359,6 +359,24 @@
     "editor.text.scheme": {
       "fgColor": "Overlay2"
     },
+    "editor.indent.guide": {
+        "fgColor": "Overlay0",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.current": {
+        "fgColor": "Overlay2",
+        "decoration": {
+            "style": "DASHED"
+        }
+    },
+    "editor.indent.guide.declaration": {
+        "fgColor": "Surface0"
+    },
+    "editor.indent.guide.declaration.current": {
+        "fgColor": "Overlay0"
+    },
     "entityReference.html": {
       "fgColor": "Red",
       "layer": 20

--- a/themes/catppuccin-mocha.json
+++ b/themes/catppuccin-mocha.json
@@ -360,22 +360,22 @@
       "fgColor": "Overlay2"
     },
     "editor.indent.guide": {
-        "fgColor": "Overlay0",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay0",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.current": {
-        "fgColor": "Overlay2",
-        "decoration": {
-            "style": "DASHED"
-        }
+      "fgColor": "Overlay2",
+      "decoration": {
+        "style": "DASHED"
+      }
     },
     "editor.indent.guide.declaration": {
-        "fgColor": "Surface0"
+      "fgColor": "Surface0"
     },
     "editor.indent.guide.declaration.current": {
-        "fgColor": "Overlay0"
+      "fgColor": "Overlay0"
     },
     "entityReference.html": {
       "fgColor": "Red",


### PR DESCRIPTION
Hello!

The most recent update of Fleet has added the ability to enable the indent guides in the editor. By default, it looks like those colors are set to a dark blue which doesn't match Catppuccin themes in other editors (like IntelliJ IDEA).

I have tried to match them as closely as possible to how the IntelliJ IDEA Catppuccin theme looks while still using the built-in colors provided by the Python library.

I found the snippet for setting the indent guide colors by setting my theme to Dark Purple and using the action "Edit Color Theme...", in case anyone is interested.

Please let me know what you think!

I have also included a before and after screenshot of the Mocha version below.

Before:
![image](https://github.com/catppuccin/fleet/assets/32999995/6abaf2d3-643c-4660-8706-01339f8af15e)

After:
![image](https://github.com/catppuccin/fleet/assets/32999995/9bbe386c-bd43-4a49-ba1a-41616986ef6d)