### PR TITLE
fix: remove lingering red text from variable names

### DIFF
--- a/fleet.tera
+++ b/fleet.tera
@@ -915,9 +915,7 @@ whiskers:
       "stripeColor": "{{ teal.hex }}40%"
     },
     "problem.unknown": {
-      "fgColor": "Red",
-      "layer": 50,
-      "stripeColor": "Red"
+      "layer": 50
     },
     "problem.unused": {
       "decoration": {

--- a/themes/catppuccin-frappe.json
+++ b/themes/catppuccin-frappe.json
@@ -887,9 +887,7 @@
       "stripeColor": "81c8be40%"
     },
     "problem.unknown": {
-      "fgColor": "Red",
-      "layer": 50,
-      "stripeColor": "Red"
+      "layer": 50
     },
     "problem.unused": {
       "decoration": {

--- a/themes/catppuccin-latte.json
+++ b/themes/catppuccin-latte.json
@@ -887,9 +887,7 @@
       "stripeColor": "17929940%"
     },
     "problem.unknown": {
-      "fgColor": "Red",
-      "layer": 50,
-      "stripeColor": "Red"
+      "layer": 50
     },
     "problem.unused": {
       "decoration": {

--- a/themes/catppuccin-macchiato.json
+++ b/themes/catppuccin-macchiato.json
@@ -887,9 +887,7 @@
       "stripeColor": "8bd5ca40%"
     },
     "problem.unknown": {
-      "fgColor": "Red",
-      "layer": 50,
-      "stripeColor": "Red"
+      "layer": 50
     },
     "problem.unused": {
       "decoration": {

--- a/themes/catppuccin-mocha.json
+++ b/themes/catppuccin-mocha.json
@@ -887,9 +887,7 @@
       "stripeColor": "94e2d540%"
     },
     "problem.unknown": {
-      "fgColor": "Red",
-      "layer": 50,
-      "stripeColor": "Red"
+      "layer": 50
     },
     "problem.unused": {
       "decoration": {


### PR DESCRIPTION
This seems to happen when you set a text colour for problem.unknown, as it will not properly be cleared when you click out of it

Default themes dont seem to use this attribute at all, so we can just avoid using it too

Closes #9