### PR TITLE
feat: add Fleet 1.37.84 support

### DIFF
--- a/fleet.tera
+++ b/fleet.tera
@@ -160,10 +160,10 @@ whiskers:
     "toggleButton.off.border.disabled": "Transparent",
 
     "iconButton.on.focusBorder": "Transparent",
-    "iconButton.on.background.default": "Transparent",
-    "iconButton.on.background.disabled": "Transparent",
-    "iconButton.on.background.hovered": "Surface0",
-    "iconButton.on.background.pressed": "Surface0",
+    "iconButton.on.background.default": "Surface0",
+    "iconButton.on.background.disabled": "Surface0",
+    "iconButton.on.background.hovered": "Surface1",
+    "iconButton.on.background.pressed": "Surface1",
     "iconButton.on.text.default": "Text",
     "iconButton.on.text.hovered": "Text",
     "iconButton.on.text.pressed": "Text",
@@ -484,152 +484,117 @@ whiskers:
     "ai.error.border": "Red",
     "ai.error.fill": "Transparent"
   },
-  "text-attributes": {
+  "textAttributes": {
     "attributeName.html": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "attributeValue.html": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "boolean": {
-      "fgColor": "Mauve",
-      "layer": 10
+      "foregroundColor": "Mauve"
     },
     "comment": {
-      "fgColor": "Overlay0",
-      "layer": 5
+      "foregroundColor": "Overlay0"
     },
     "comment.doc": {
-      "fgColor": "Overlay0",
-      "layer": 6
+      "foregroundColor": "Overlay0"
     },
     "comment.doc.value": {
-      "fgColor": "Overlay1",
-      "layer": 10
+      "foregroundColor": "Overlay1"
     },
     "comment.doc.tag": {
-      "fgColor": "Maroon",
-      "layer": 10
+      "foregroundColor": "Maroon"
     },
     "comment.todo": {
-      "fgColor": "Yellow",
-      "layer": 10
+      "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "bgColor": "Blue",
-      "fullLine": true,
-      "layer": -68
+      "backgroundColor": "Blue"
     },
     "diff.added": {
-      "bgColor": "{{ green.hex }}{{ diff_added_opacity }}",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "{{ green.hex }}{{ diff_added_opacity }}",
       "stripeColor": "{{ green.hex }}{{ diff_added_opacity }}"
     },
     "diff.added.empty": {
-      "bgColor": "{{ green.hex }}{{ diff_added_opacity }}",
-      "layer": -60,
+      "backgroundColor": "{{ green.hex }}{{ diff_added_opacity }}",
       "showEmptyIntervals": true
     },
     "diff.added.withBorder": {
-      "bgColor": "{{ green.hex }}{{ diff_added_opacity }}",
+      "backgroundColor": "{{ green.hex }}{{ diff_added_opacity }}",
       "decoration": {
         "color": "{{ green.hex }}{{ diff_added_opacity }}",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.added.word": {
-      "bgColor": "{{ green.hex }}{{ diff_added_opacity }}",
-      "layer": -60
+      "backgroundColor": "{{ green.hex }}{{ diff_added_opacity }}"
     },
     "diff.conflict.withBorder": {
-      "bgColor": "{{ red.hex }}{{ diff_conflict_opacity }}",
+      "backgroundColor": "{{ red.hex }}{{ diff_conflict_opacity }}",
       "decoration": {
         "color": "Red",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -68
+      }
     },
     "diff.deleted": {
-      "bgColor": "{{ red.hex }}{{ diff_deleted_opacity }}",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "{{ red.hex }}{{ diff_deleted_opacity }}",
       "stripeColor": "{{ red.hex }}{{ diff_deleted_opacity }}"
     },
     "diff.deleted.empty": {
-      "bgColor": "{{ red.hex }}{{ diff_deleted_opacity }}",
-      "layer": -60,
+      "backgroundColor": "{{ red.hex }}{{ diff_deleted_opacity }}",
       "showEmptyIntervals": true
     },
     "diff.deleted.withBorder": {
-      "bgColor": "{{ red.hex }}{{ diff_deleted_opacity }}",
+      "backgroundColor": "{{ red.hex }}{{ diff_deleted_opacity }}",
       "decoration": {
         "color": "{{ red.hex }}{{ diff_deleted_opacity }}",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.deleted.word": {
-      "bgColor": "{{ red.hex }}{{ diff_deleted_opacity }}",
-      "layer": -60,
+      "backgroundColor": "{{ red.hex }}{{ diff_deleted_opacity }}",
       "showEmptyIntervals": true
     },
     "diff.modified": {
-      "bgColor": "{{ blue.hex }}{{ diff_deleted_opacity }}",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "{{ blue.hex }}{{ diff_deleted_opacity }}",
       "stripeColor": "{{ blue.hex }}{{ diff_deleted_opacity }}"
     },
     "diff.modified.withBorder": {
-      "bgColor": "{{ blue.hex }}{{ diff_deleted_opacity }}",
+      "backgroundColor": "{{ blue.hex }}{{ diff_deleted_opacity }}",
       "decoration": {
         "color": "{{ blue.hex }}{{ diff_deleted_opacity }}",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.modified.word": {
-      "bgColor": "{{ blue.hex }}{{ diff_deleted_opacity }}",
-      "layer": -60
+      "backgroundColor": "{{ blue.hex }}{{ diff_deleted_opacity }}"
     },
     "editor.brace.match": {
-      "bgColor": "Surface1",
-      "layer": 300
+      "backgroundColor": "Surface1"
     },
     "editor.rename.current": {
       "decoration": {
         "color": "Lavender",
         "style": "BORDER"
       },
-      "layer": 100,
       "showEmptyIntervals": true
     },
     "editor.rename.entries": {
-      "bgColor": "Transparent",
-      "layer": 100,
+      "backgroundColor": "Transparent",
       "showEmptyIntervals": true,
       "stripeColor": "Surface0"
     },
     "editor.search.results": {
-      "bgColor": "{{ blue.hex }}40%",
-      "layer": 100,
+      "backgroundColor": "{{ blue.hex }}40%",
       "stripeColor": "Blue"
     },
     {#- No qualifier refers to unfocused #}
     "editor.selection": {
-      "bgColor": "Surface2",
-      "layer": 2000
+      "backgroundColor": "Surface2"
     },
     "editor.selection.focused": {
-      "bgColor": "Surface1",
-      "layer": 2000
+      "backgroundColor": "Surface1"
     },
     "editor.text.composable": {
       "decoration": {
@@ -637,192 +602,156 @@ whiskers:
       }
     },
     "editor.text.scheme": {
-      "fgColor": "Text"
+      "foregroundColor": "Text"
     },
-    "editor.indent.guide": {
-      "fgColor": "Overlay0",
+    "editor.indentGuide": {
+      "foregroundColor": "Overlay0",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.current": {
-      "fgColor": "Overlay2",
+    "editor.indentGuide.current": {
+      "foregroundColor": "Overlay2",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.declaration": {
-      "fgColor": "Surface0"
+    "editor.indentGuide.declaration": {
+      "foregroundColor": "Surface0"
     },
-    "editor.indent.guide.declaration.current": {
-      "fgColor": "Overlay0"
+    "editor.indentGuide.declaration.current": {
+      "foregroundColor": "Overlay0"
     },
     "entityReference.html": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier": {
-      "fgColor": "Text",
-      "layer": 10
+      "foregroundColor": "Text"
     },
     "identifier.alias.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.anchor.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant.predefined": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier.field": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.field.static": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.function.call": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.package": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.suspend": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.declaration": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.interface": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.method.static": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.methodReceiver.go": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.namedArgument": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.other": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.package.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.parameter": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.this": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "identifier.this.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
     "identifier.type": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.class": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.enum": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.struct": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.valueType": {
-      "fgColor": "Lavender",
-      "layer": 20
+      "foregroundColor": "Lavender"
     },
     "identifier.typeDeclaration.go": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeParameter": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeReference.go": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.underCaret": {
-      "bgColor": "Transparent",
+      "backgroundColor": "Transparent",
       "decoration": {
         "color": "Surface2",
         "style": "BORDER"
-      },
-      "layer": 1000
+      }
     },
     "identifier.variable": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.variable.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
+    "key.json": {
+      "foregroundColor": "Blue"
+    },
     "key.yaml": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "keyword": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "keyword.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "keyword.extend.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "keyword.global.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "keyword.important.css": {
-      "fgColor": "Lavender",
+      "foregroundColor": "Lavender",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "keyword.typeModifier": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "link": {},
     "link.always.visible": {
@@ -832,80 +761,65 @@ whiskers:
       "decoration": {
         "color": "Blue"
       },
-      "fgColor": "Sapphire",
-      "layer": 100
+      "foregroundColor": "Sapphire"
     },
     "markup.bold": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "bold": true
-      },
-      "layer": 20
+      }
     },
     "markup.code.block": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "markup.heading": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "markup.href": {
       "decoration": {},
-      "fgColor": "Rosewater",
+      "foregroundColor": "Rosewater",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "markup.italic": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "metadata": {
-      "fgColor": "Yellow",
-      "layer": 25
+      "foregroundColor": "Yellow"
     },
     "metadata.structTag.key.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "metadata.structTag.value.go": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "number": {
-      "fgColor": "Peach",
-      "layer": 10
+      "foregroundColor": "Peach"
     },
     "number.css": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "number.unit.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "other.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "problem.deprecated": {
       "decoration": {
         "color": "Overlay2",
         "position": "THROUGH"
-      },
-      "layer": 30
+      }
     },
     "problem.error": {
       "decoration": {
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 70,
       "stripeColor": "Red"
     },
     "problem.error.badCharacter": {
@@ -913,7 +827,6 @@ whiskers:
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 100,
       "showEmptyIntervals": true,
       "stripeColor": "Red"
     },
@@ -922,22 +835,18 @@ whiskers:
         "color": "{{ teal.hex }}40%",
         "style": "BORDER"
       },
-      "layer": 50,
       "stripeColor": "{{ teal.hex }}40%"
     },
     "problem.unknown": {
-      "layer": 50
     },
     "problem.unused": {
-      "fgColor": "Overlay0",
-      "layer": 60
+      "foregroundColor": "Overlay0"
     },
     "problem.warning": {
       "decoration": {
         "color": "Yellow",
         "thickness": 2.0
       },
-      "layer": 60,
       "stripeColor": "Yellow"
     },
     "problem.warning.weak": {
@@ -945,110 +854,85 @@ whiskers:
         "color": "{{ yellow.hex }}40%",
         "thickness": 2.0
       },
-      "layer": 40,
       "stripeColor": "{{ yellow.hex }}40%"
     },
     "propertyName.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "propertyValue.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "punctuation": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.css": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator.merge.yaml": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "selector.class.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "selector.id.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "selector.pseudo.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.tag.css": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "snippet": {
-      "bgColor": "Blue",
+      "backgroundColor": "Blue",
       "borderRadius": 4.0,
       "showEmptyIntervals": true
     },
     "string": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.binary": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "string.escape": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.alternative": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.unicode": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.formatItem": {
-      "fgColor": "Peach",
-      "layer": 25
+      "foregroundColor": "Peach"
     },
     "string.regexp": {
-      "fgColor": "Green",
-      "layer": 25
+      "foregroundColor": "Green"
     },
     "tag.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "tagName.custom.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "tagName.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "transparent": {},
     "url.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "value.yaml": {
-      "fgColor": "Text",
-      "layer": 2
+      "foregroundColor": "Text"
     }
   },
   "palette": {

--- a/themes/catppuccin-frappe.json
+++ b/themes/catppuccin-frappe.json
@@ -139,10 +139,10 @@
     "toggleButton.off.border.disabled": "Transparent",
 
     "iconButton.on.focusBorder": "Transparent",
-    "iconButton.on.background.default": "Transparent",
-    "iconButton.on.background.disabled": "Transparent",
-    "iconButton.on.background.hovered": "Surface0",
-    "iconButton.on.background.pressed": "Surface0",
+    "iconButton.on.background.default": "Surface0",
+    "iconButton.on.background.disabled": "Surface0",
+    "iconButton.on.background.hovered": "Surface1",
+    "iconButton.on.background.pressed": "Surface1",
     "iconButton.on.text.default": "Text",
     "iconButton.on.text.hovered": "Text",
     "iconButton.on.text.pressed": "Text",
@@ -454,151 +454,116 @@
     "ai.error.border": "Red",
     "ai.error.fill": "Transparent"
   },
-  "text-attributes": {
+  "textAttributes": {
     "attributeName.html": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "attributeValue.html": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "boolean": {
-      "fgColor": "Mauve",
-      "layer": 10
+      "foregroundColor": "Mauve"
     },
     "comment": {
-      "fgColor": "Overlay0",
-      "layer": 5
+      "foregroundColor": "Overlay0"
     },
     "comment.doc": {
-      "fgColor": "Overlay0",
-      "layer": 6
+      "foregroundColor": "Overlay0"
     },
     "comment.doc.value": {
-      "fgColor": "Overlay1",
-      "layer": 10
+      "foregroundColor": "Overlay1"
     },
     "comment.doc.tag": {
-      "fgColor": "Maroon",
-      "layer": 10
+      "foregroundColor": "Maroon"
     },
     "comment.todo": {
-      "fgColor": "Yellow",
-      "layer": 10
+      "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "bgColor": "Blue",
-      "fullLine": true,
-      "layer": -68
+      "backgroundColor": "Blue"
     },
     "diff.added": {
-      "bgColor": "a6d18920%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "a6d18920%",
       "stripeColor": "a6d18920%"
     },
     "diff.added.empty": {
-      "bgColor": "a6d18920%",
-      "layer": -60,
+      "backgroundColor": "a6d18920%",
       "showEmptyIntervals": true
     },
     "diff.added.withBorder": {
-      "bgColor": "a6d18920%",
+      "backgroundColor": "a6d18920%",
       "decoration": {
         "color": "a6d18920%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.added.word": {
-      "bgColor": "a6d18920%",
-      "layer": -60
+      "backgroundColor": "a6d18920%"
     },
     "diff.conflict.withBorder": {
-      "bgColor": "e7828430%",
+      "backgroundColor": "e7828430%",
       "decoration": {
         "color": "Red",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -68
+      }
     },
     "diff.deleted": {
-      "bgColor": "e7828420%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "e7828420%",
       "stripeColor": "e7828420%"
     },
     "diff.deleted.empty": {
-      "bgColor": "e7828420%",
-      "layer": -60,
+      "backgroundColor": "e7828420%",
       "showEmptyIntervals": true
     },
     "diff.deleted.withBorder": {
-      "bgColor": "e7828420%",
+      "backgroundColor": "e7828420%",
       "decoration": {
         "color": "e7828420%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.deleted.word": {
-      "bgColor": "e7828420%",
-      "layer": -60,
+      "backgroundColor": "e7828420%",
       "showEmptyIntervals": true
     },
     "diff.modified": {
-      "bgColor": "8caaee20%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "8caaee20%",
       "stripeColor": "8caaee20%"
     },
     "diff.modified.withBorder": {
-      "bgColor": "8caaee20%",
+      "backgroundColor": "8caaee20%",
       "decoration": {
         "color": "8caaee20%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.modified.word": {
-      "bgColor": "8caaee20%",
-      "layer": -60
+      "backgroundColor": "8caaee20%"
     },
     "editor.brace.match": {
-      "bgColor": "Surface1",
-      "layer": 300
+      "backgroundColor": "Surface1"
     },
     "editor.rename.current": {
       "decoration": {
         "color": "Lavender",
         "style": "BORDER"
       },
-      "layer": 100,
       "showEmptyIntervals": true
     },
     "editor.rename.entries": {
-      "bgColor": "Transparent",
-      "layer": 100,
+      "backgroundColor": "Transparent",
       "showEmptyIntervals": true,
       "stripeColor": "Surface0"
     },
     "editor.search.results": {
-      "bgColor": "8caaee40%",
-      "layer": 100,
+      "backgroundColor": "8caaee40%",
       "stripeColor": "Blue"
     },
     "editor.selection": {
-      "bgColor": "Surface2",
-      "layer": 2000
+      "backgroundColor": "Surface2"
     },
     "editor.selection.focused": {
-      "bgColor": "Surface1",
-      "layer": 2000
+      "backgroundColor": "Surface1"
     },
     "editor.text.composable": {
       "decoration": {
@@ -606,192 +571,156 @@
       }
     },
     "editor.text.scheme": {
-      "fgColor": "Text"
+      "foregroundColor": "Text"
     },
-    "editor.indent.guide": {
-      "fgColor": "Overlay0",
+    "editor.indentGuide": {
+      "foregroundColor": "Overlay0",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.current": {
-      "fgColor": "Overlay2",
+    "editor.indentGuide.current": {
+      "foregroundColor": "Overlay2",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.declaration": {
-      "fgColor": "Surface0"
+    "editor.indentGuide.declaration": {
+      "foregroundColor": "Surface0"
     },
-    "editor.indent.guide.declaration.current": {
-      "fgColor": "Overlay0"
+    "editor.indentGuide.declaration.current": {
+      "foregroundColor": "Overlay0"
     },
     "entityReference.html": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier": {
-      "fgColor": "Text",
-      "layer": 10
+      "foregroundColor": "Text"
     },
     "identifier.alias.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.anchor.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant.predefined": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier.field": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.field.static": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.function.call": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.package": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.suspend": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.declaration": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.interface": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.method.static": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.methodReceiver.go": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.namedArgument": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.other": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.package.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.parameter": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.this": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "identifier.this.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
     "identifier.type": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.class": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.enum": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.struct": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.valueType": {
-      "fgColor": "Lavender",
-      "layer": 20
+      "foregroundColor": "Lavender"
     },
     "identifier.typeDeclaration.go": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeParameter": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeReference.go": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.underCaret": {
-      "bgColor": "Transparent",
+      "backgroundColor": "Transparent",
       "decoration": {
         "color": "Surface2",
         "style": "BORDER"
-      },
-      "layer": 1000
+      }
     },
     "identifier.variable": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.variable.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
+    "key.json": {
+      "foregroundColor": "Blue"
+    },
     "key.yaml": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "keyword": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "keyword.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "keyword.extend.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "keyword.global.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "keyword.important.css": {
-      "fgColor": "Lavender",
+      "foregroundColor": "Lavender",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "keyword.typeModifier": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "link": {},
     "link.always.visible": {
@@ -801,80 +730,65 @@
       "decoration": {
         "color": "Blue"
       },
-      "fgColor": "Sapphire",
-      "layer": 100
+      "foregroundColor": "Sapphire"
     },
     "markup.bold": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "bold": true
-      },
-      "layer": 20
+      }
     },
     "markup.code.block": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "markup.heading": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "markup.href": {
       "decoration": {},
-      "fgColor": "Rosewater",
+      "foregroundColor": "Rosewater",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "markup.italic": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "metadata": {
-      "fgColor": "Yellow",
-      "layer": 25
+      "foregroundColor": "Yellow"
     },
     "metadata.structTag.key.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "metadata.structTag.value.go": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "number": {
-      "fgColor": "Peach",
-      "layer": 10
+      "foregroundColor": "Peach"
     },
     "number.css": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "number.unit.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "other.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "problem.deprecated": {
       "decoration": {
         "color": "Overlay2",
         "position": "THROUGH"
-      },
-      "layer": 30
+      }
     },
     "problem.error": {
       "decoration": {
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 70,
       "stripeColor": "Red"
     },
     "problem.error.badCharacter": {
@@ -882,7 +796,6 @@
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 100,
       "showEmptyIntervals": true,
       "stripeColor": "Red"
     },
@@ -891,22 +804,18 @@
         "color": "81c8be40%",
         "style": "BORDER"
       },
-      "layer": 50,
       "stripeColor": "81c8be40%"
     },
     "problem.unknown": {
-      "layer": 50
     },
     "problem.unused": {
-      "fgColor": "Overlay0",
-      "layer": 60
+      "foregroundColor": "Overlay0"
     },
     "problem.warning": {
       "decoration": {
         "color": "Yellow",
         "thickness": 2.0
       },
-      "layer": 60,
       "stripeColor": "Yellow"
     },
     "problem.warning.weak": {
@@ -914,110 +823,85 @@
         "color": "e5c89040%",
         "thickness": 2.0
       },
-      "layer": 40,
       "stripeColor": "e5c89040%"
     },
     "propertyName.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "propertyValue.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "punctuation": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.css": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator.merge.yaml": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "selector.class.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "selector.id.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "selector.pseudo.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.tag.css": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "snippet": {
-      "bgColor": "Blue",
+      "backgroundColor": "Blue",
       "borderRadius": 4.0,
       "showEmptyIntervals": true
     },
     "string": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.binary": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "string.escape": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.alternative": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.unicode": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.formatItem": {
-      "fgColor": "Peach",
-      "layer": 25
+      "foregroundColor": "Peach"
     },
     "string.regexp": {
-      "fgColor": "Green",
-      "layer": 25
+      "foregroundColor": "Green"
     },
     "tag.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "tagName.custom.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "tagName.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "transparent": {},
     "url.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "value.yaml": {
-      "fgColor": "Text",
-      "layer": 2
+      "foregroundColor": "Text"
     }
   },
   "palette": {

--- a/themes/catppuccin-latte.json
+++ b/themes/catppuccin-latte.json
@@ -139,10 +139,10 @@
     "toggleButton.off.border.disabled": "Transparent",
 
     "iconButton.on.focusBorder": "Transparent",
-    "iconButton.on.background.default": "Transparent",
-    "iconButton.on.background.disabled": "Transparent",
-    "iconButton.on.background.hovered": "Surface0",
-    "iconButton.on.background.pressed": "Surface0",
+    "iconButton.on.background.default": "Surface0",
+    "iconButton.on.background.disabled": "Surface0",
+    "iconButton.on.background.hovered": "Surface1",
+    "iconButton.on.background.pressed": "Surface1",
     "iconButton.on.text.default": "Text",
     "iconButton.on.text.hovered": "Text",
     "iconButton.on.text.pressed": "Text",
@@ -455,151 +455,116 @@
     "ai.error.border": "Red",
     "ai.error.fill": "Transparent"
   },
-  "text-attributes": {
+  "textAttributes": {
     "attributeName.html": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "attributeValue.html": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "boolean": {
-      "fgColor": "Mauve",
-      "layer": 10
+      "foregroundColor": "Mauve"
     },
     "comment": {
-      "fgColor": "Overlay0",
-      "layer": 5
+      "foregroundColor": "Overlay0"
     },
     "comment.doc": {
-      "fgColor": "Overlay0",
-      "layer": 6
+      "foregroundColor": "Overlay0"
     },
     "comment.doc.value": {
-      "fgColor": "Overlay1",
-      "layer": 10
+      "foregroundColor": "Overlay1"
     },
     "comment.doc.tag": {
-      "fgColor": "Maroon",
-      "layer": 10
+      "foregroundColor": "Maroon"
     },
     "comment.todo": {
-      "fgColor": "Yellow",
-      "layer": 10
+      "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "bgColor": "Blue",
-      "fullLine": true,
-      "layer": -68
+      "backgroundColor": "Blue"
     },
     "diff.added": {
-      "bgColor": "40a02b20%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "40a02b20%",
       "stripeColor": "40a02b20%"
     },
     "diff.added.empty": {
-      "bgColor": "40a02b20%",
-      "layer": -60,
+      "backgroundColor": "40a02b20%",
       "showEmptyIntervals": true
     },
     "diff.added.withBorder": {
-      "bgColor": "40a02b20%",
+      "backgroundColor": "40a02b20%",
       "decoration": {
         "color": "40a02b20%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.added.word": {
-      "bgColor": "40a02b20%",
-      "layer": -60
+      "backgroundColor": "40a02b20%"
     },
     "diff.conflict.withBorder": {
-      "bgColor": "d20f3920%",
+      "backgroundColor": "d20f3920%",
       "decoration": {
         "color": "Red",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -68
+      }
     },
     "diff.deleted": {
-      "bgColor": "d20f3910%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "d20f3910%",
       "stripeColor": "d20f3910%"
     },
     "diff.deleted.empty": {
-      "bgColor": "d20f3910%",
-      "layer": -60,
+      "backgroundColor": "d20f3910%",
       "showEmptyIntervals": true
     },
     "diff.deleted.withBorder": {
-      "bgColor": "d20f3910%",
+      "backgroundColor": "d20f3910%",
       "decoration": {
         "color": "d20f3910%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.deleted.word": {
-      "bgColor": "d20f3910%",
-      "layer": -60,
+      "backgroundColor": "d20f3910%",
       "showEmptyIntervals": true
     },
     "diff.modified": {
-      "bgColor": "1e66f510%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "1e66f510%",
       "stripeColor": "1e66f510%"
     },
     "diff.modified.withBorder": {
-      "bgColor": "1e66f510%",
+      "backgroundColor": "1e66f510%",
       "decoration": {
         "color": "1e66f510%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.modified.word": {
-      "bgColor": "1e66f510%",
-      "layer": -60
+      "backgroundColor": "1e66f510%"
     },
     "editor.brace.match": {
-      "bgColor": "Surface1",
-      "layer": 300
+      "backgroundColor": "Surface1"
     },
     "editor.rename.current": {
       "decoration": {
         "color": "Lavender",
         "style": "BORDER"
       },
-      "layer": 100,
       "showEmptyIntervals": true
     },
     "editor.rename.entries": {
-      "bgColor": "Transparent",
-      "layer": 100,
+      "backgroundColor": "Transparent",
       "showEmptyIntervals": true,
       "stripeColor": "Surface0"
     },
     "editor.search.results": {
-      "bgColor": "1e66f540%",
-      "layer": 100,
+      "backgroundColor": "1e66f540%",
       "stripeColor": "Blue"
     },
     "editor.selection": {
-      "bgColor": "Surface2",
-      "layer": 2000
+      "backgroundColor": "Surface2"
     },
     "editor.selection.focused": {
-      "bgColor": "Surface1",
-      "layer": 2000
+      "backgroundColor": "Surface1"
     },
     "editor.text.composable": {
       "decoration": {
@@ -607,192 +572,156 @@
       }
     },
     "editor.text.scheme": {
-      "fgColor": "Text"
+      "foregroundColor": "Text"
     },
-    "editor.indent.guide": {
-      "fgColor": "Overlay0",
+    "editor.indentGuide": {
+      "foregroundColor": "Overlay0",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.current": {
-      "fgColor": "Overlay2",
+    "editor.indentGuide.current": {
+      "foregroundColor": "Overlay2",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.declaration": {
-      "fgColor": "Surface0"
+    "editor.indentGuide.declaration": {
+      "foregroundColor": "Surface0"
     },
-    "editor.indent.guide.declaration.current": {
-      "fgColor": "Overlay0"
+    "editor.indentGuide.declaration.current": {
+      "foregroundColor": "Overlay0"
     },
     "entityReference.html": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier": {
-      "fgColor": "Text",
-      "layer": 10
+      "foregroundColor": "Text"
     },
     "identifier.alias.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.anchor.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant.predefined": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier.field": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.field.static": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.function.call": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.package": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.suspend": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.declaration": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.interface": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.method.static": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.methodReceiver.go": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.namedArgument": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.other": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.package.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.parameter": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.this": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "identifier.this.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
     "identifier.type": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.class": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.enum": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.struct": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.valueType": {
-      "fgColor": "Lavender",
-      "layer": 20
+      "foregroundColor": "Lavender"
     },
     "identifier.typeDeclaration.go": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeParameter": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeReference.go": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.underCaret": {
-      "bgColor": "Transparent",
+      "backgroundColor": "Transparent",
       "decoration": {
         "color": "Surface2",
         "style": "BORDER"
-      },
-      "layer": 1000
+      }
     },
     "identifier.variable": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.variable.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
+    "key.json": {
+      "foregroundColor": "Blue"
+    },
     "key.yaml": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "keyword": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "keyword.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "keyword.extend.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "keyword.global.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "keyword.important.css": {
-      "fgColor": "Lavender",
+      "foregroundColor": "Lavender",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "keyword.typeModifier": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "link": {},
     "link.always.visible": {
@@ -802,80 +731,65 @@
       "decoration": {
         "color": "Blue"
       },
-      "fgColor": "Sapphire",
-      "layer": 100
+      "foregroundColor": "Sapphire"
     },
     "markup.bold": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "bold": true
-      },
-      "layer": 20
+      }
     },
     "markup.code.block": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "markup.heading": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "markup.href": {
       "decoration": {},
-      "fgColor": "Rosewater",
+      "foregroundColor": "Rosewater",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "markup.italic": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "metadata": {
-      "fgColor": "Yellow",
-      "layer": 25
+      "foregroundColor": "Yellow"
     },
     "metadata.structTag.key.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "metadata.structTag.value.go": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "number": {
-      "fgColor": "Peach",
-      "layer": 10
+      "foregroundColor": "Peach"
     },
     "number.css": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "number.unit.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "other.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "problem.deprecated": {
       "decoration": {
         "color": "Overlay2",
         "position": "THROUGH"
-      },
-      "layer": 30
+      }
     },
     "problem.error": {
       "decoration": {
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 70,
       "stripeColor": "Red"
     },
     "problem.error.badCharacter": {
@@ -883,7 +797,6 @@
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 100,
       "showEmptyIntervals": true,
       "stripeColor": "Red"
     },
@@ -892,22 +805,18 @@
         "color": "17929940%",
         "style": "BORDER"
       },
-      "layer": 50,
       "stripeColor": "17929940%"
     },
     "problem.unknown": {
-      "layer": 50
     },
     "problem.unused": {
-      "fgColor": "Overlay0",
-      "layer": 60
+      "foregroundColor": "Overlay0"
     },
     "problem.warning": {
       "decoration": {
         "color": "Yellow",
         "thickness": 2.0
       },
-      "layer": 60,
       "stripeColor": "Yellow"
     },
     "problem.warning.weak": {
@@ -915,110 +824,85 @@
         "color": "df8e1d40%",
         "thickness": 2.0
       },
-      "layer": 40,
       "stripeColor": "df8e1d40%"
     },
     "propertyName.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "propertyValue.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "punctuation": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.css": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator.merge.yaml": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "selector.class.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "selector.id.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "selector.pseudo.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.tag.css": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "snippet": {
-      "bgColor": "Blue",
+      "backgroundColor": "Blue",
       "borderRadius": 4.0,
       "showEmptyIntervals": true
     },
     "string": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.binary": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "string.escape": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.alternative": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.unicode": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.formatItem": {
-      "fgColor": "Peach",
-      "layer": 25
+      "foregroundColor": "Peach"
     },
     "string.regexp": {
-      "fgColor": "Green",
-      "layer": 25
+      "foregroundColor": "Green"
     },
     "tag.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "tagName.custom.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "tagName.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "transparent": {},
     "url.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "value.yaml": {
-      "fgColor": "Text",
-      "layer": 2
+      "foregroundColor": "Text"
     }
   },
   "palette": {

--- a/themes/catppuccin-macchiato.json
+++ b/themes/catppuccin-macchiato.json
@@ -139,10 +139,10 @@
     "toggleButton.off.border.disabled": "Transparent",
 
     "iconButton.on.focusBorder": "Transparent",
-    "iconButton.on.background.default": "Transparent",
-    "iconButton.on.background.disabled": "Transparent",
-    "iconButton.on.background.hovered": "Surface0",
-    "iconButton.on.background.pressed": "Surface0",
+    "iconButton.on.background.default": "Surface0",
+    "iconButton.on.background.disabled": "Surface0",
+    "iconButton.on.background.hovered": "Surface1",
+    "iconButton.on.background.pressed": "Surface1",
     "iconButton.on.text.default": "Text",
     "iconButton.on.text.hovered": "Text",
     "iconButton.on.text.pressed": "Text",
@@ -454,151 +454,116 @@
     "ai.error.border": "Red",
     "ai.error.fill": "Transparent"
   },
-  "text-attributes": {
+  "textAttributes": {
     "attributeName.html": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "attributeValue.html": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "boolean": {
-      "fgColor": "Mauve",
-      "layer": 10
+      "foregroundColor": "Mauve"
     },
     "comment": {
-      "fgColor": "Overlay0",
-      "layer": 5
+      "foregroundColor": "Overlay0"
     },
     "comment.doc": {
-      "fgColor": "Overlay0",
-      "layer": 6
+      "foregroundColor": "Overlay0"
     },
     "comment.doc.value": {
-      "fgColor": "Overlay1",
-      "layer": 10
+      "foregroundColor": "Overlay1"
     },
     "comment.doc.tag": {
-      "fgColor": "Maroon",
-      "layer": 10
+      "foregroundColor": "Maroon"
     },
     "comment.todo": {
-      "fgColor": "Yellow",
-      "layer": 10
+      "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "bgColor": "Blue",
-      "fullLine": true,
-      "layer": -68
+      "backgroundColor": "Blue"
     },
     "diff.added": {
-      "bgColor": "a6da9520%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "a6da9520%",
       "stripeColor": "a6da9520%"
     },
     "diff.added.empty": {
-      "bgColor": "a6da9520%",
-      "layer": -60,
+      "backgroundColor": "a6da9520%",
       "showEmptyIntervals": true
     },
     "diff.added.withBorder": {
-      "bgColor": "a6da9520%",
+      "backgroundColor": "a6da9520%",
       "decoration": {
         "color": "a6da9520%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.added.word": {
-      "bgColor": "a6da9520%",
-      "layer": -60
+      "backgroundColor": "a6da9520%"
     },
     "diff.conflict.withBorder": {
-      "bgColor": "ed879630%",
+      "backgroundColor": "ed879630%",
       "decoration": {
         "color": "Red",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -68
+      }
     },
     "diff.deleted": {
-      "bgColor": "ed879620%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "ed879620%",
       "stripeColor": "ed879620%"
     },
     "diff.deleted.empty": {
-      "bgColor": "ed879620%",
-      "layer": -60,
+      "backgroundColor": "ed879620%",
       "showEmptyIntervals": true
     },
     "diff.deleted.withBorder": {
-      "bgColor": "ed879620%",
+      "backgroundColor": "ed879620%",
       "decoration": {
         "color": "ed879620%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.deleted.word": {
-      "bgColor": "ed879620%",
-      "layer": -60,
+      "backgroundColor": "ed879620%",
       "showEmptyIntervals": true
     },
     "diff.modified": {
-      "bgColor": "8aadf420%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "8aadf420%",
       "stripeColor": "8aadf420%"
     },
     "diff.modified.withBorder": {
-      "bgColor": "8aadf420%",
+      "backgroundColor": "8aadf420%",
       "decoration": {
         "color": "8aadf420%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.modified.word": {
-      "bgColor": "8aadf420%",
-      "layer": -60
+      "backgroundColor": "8aadf420%"
     },
     "editor.brace.match": {
-      "bgColor": "Surface1",
-      "layer": 300
+      "backgroundColor": "Surface1"
     },
     "editor.rename.current": {
       "decoration": {
         "color": "Lavender",
         "style": "BORDER"
       },
-      "layer": 100,
       "showEmptyIntervals": true
     },
     "editor.rename.entries": {
-      "bgColor": "Transparent",
-      "layer": 100,
+      "backgroundColor": "Transparent",
       "showEmptyIntervals": true,
       "stripeColor": "Surface0"
     },
     "editor.search.results": {
-      "bgColor": "8aadf440%",
-      "layer": 100,
+      "backgroundColor": "8aadf440%",
       "stripeColor": "Blue"
     },
     "editor.selection": {
-      "bgColor": "Surface2",
-      "layer": 2000
+      "backgroundColor": "Surface2"
     },
     "editor.selection.focused": {
-      "bgColor": "Surface1",
-      "layer": 2000
+      "backgroundColor": "Surface1"
     },
     "editor.text.composable": {
       "decoration": {
@@ -606,192 +571,156 @@
       }
     },
     "editor.text.scheme": {
-      "fgColor": "Text"
+      "foregroundColor": "Text"
     },
-    "editor.indent.guide": {
-      "fgColor": "Overlay0",
+    "editor.indentGuide": {
+      "foregroundColor": "Overlay0",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.current": {
-      "fgColor": "Overlay2",
+    "editor.indentGuide.current": {
+      "foregroundColor": "Overlay2",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.declaration": {
-      "fgColor": "Surface0"
+    "editor.indentGuide.declaration": {
+      "foregroundColor": "Surface0"
     },
-    "editor.indent.guide.declaration.current": {
-      "fgColor": "Overlay0"
+    "editor.indentGuide.declaration.current": {
+      "foregroundColor": "Overlay0"
     },
     "entityReference.html": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier": {
-      "fgColor": "Text",
-      "layer": 10
+      "foregroundColor": "Text"
     },
     "identifier.alias.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.anchor.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant.predefined": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier.field": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.field.static": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.function.call": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.package": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.suspend": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.declaration": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.interface": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.method.static": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.methodReceiver.go": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.namedArgument": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.other": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.package.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.parameter": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.this": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "identifier.this.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
     "identifier.type": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.class": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.enum": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.struct": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.valueType": {
-      "fgColor": "Lavender",
-      "layer": 20
+      "foregroundColor": "Lavender"
     },
     "identifier.typeDeclaration.go": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeParameter": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeReference.go": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.underCaret": {
-      "bgColor": "Transparent",
+      "backgroundColor": "Transparent",
       "decoration": {
         "color": "Surface2",
         "style": "BORDER"
-      },
-      "layer": 1000
+      }
     },
     "identifier.variable": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.variable.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
+    "key.json": {
+      "foregroundColor": "Blue"
+    },
     "key.yaml": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "keyword": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "keyword.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "keyword.extend.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "keyword.global.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "keyword.important.css": {
-      "fgColor": "Lavender",
+      "foregroundColor": "Lavender",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "keyword.typeModifier": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "link": {},
     "link.always.visible": {
@@ -801,80 +730,65 @@
       "decoration": {
         "color": "Blue"
       },
-      "fgColor": "Sapphire",
-      "layer": 100
+      "foregroundColor": "Sapphire"
     },
     "markup.bold": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "bold": true
-      },
-      "layer": 20
+      }
     },
     "markup.code.block": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "markup.heading": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "markup.href": {
       "decoration": {},
-      "fgColor": "Rosewater",
+      "foregroundColor": "Rosewater",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "markup.italic": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "metadata": {
-      "fgColor": "Yellow",
-      "layer": 25
+      "foregroundColor": "Yellow"
     },
     "metadata.structTag.key.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "metadata.structTag.value.go": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "number": {
-      "fgColor": "Peach",
-      "layer": 10
+      "foregroundColor": "Peach"
     },
     "number.css": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "number.unit.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "other.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "problem.deprecated": {
       "decoration": {
         "color": "Overlay2",
         "position": "THROUGH"
-      },
-      "layer": 30
+      }
     },
     "problem.error": {
       "decoration": {
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 70,
       "stripeColor": "Red"
     },
     "problem.error.badCharacter": {
@@ -882,7 +796,6 @@
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 100,
       "showEmptyIntervals": true,
       "stripeColor": "Red"
     },
@@ -891,22 +804,18 @@
         "color": "8bd5ca40%",
         "style": "BORDER"
       },
-      "layer": 50,
       "stripeColor": "8bd5ca40%"
     },
     "problem.unknown": {
-      "layer": 50
     },
     "problem.unused": {
-      "fgColor": "Overlay0",
-      "layer": 60
+      "foregroundColor": "Overlay0"
     },
     "problem.warning": {
       "decoration": {
         "color": "Yellow",
         "thickness": 2.0
       },
-      "layer": 60,
       "stripeColor": "Yellow"
     },
     "problem.warning.weak": {
@@ -914,110 +823,85 @@
         "color": "eed49f40%",
         "thickness": 2.0
       },
-      "layer": 40,
       "stripeColor": "eed49f40%"
     },
     "propertyName.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "propertyValue.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "punctuation": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.css": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator.merge.yaml": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "selector.class.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "selector.id.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "selector.pseudo.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.tag.css": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "snippet": {
-      "bgColor": "Blue",
+      "backgroundColor": "Blue",
       "borderRadius": 4.0,
       "showEmptyIntervals": true
     },
     "string": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.binary": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "string.escape": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.alternative": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.unicode": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.formatItem": {
-      "fgColor": "Peach",
-      "layer": 25
+      "foregroundColor": "Peach"
     },
     "string.regexp": {
-      "fgColor": "Green",
-      "layer": 25
+      "foregroundColor": "Green"
     },
     "tag.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "tagName.custom.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "tagName.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "transparent": {},
     "url.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "value.yaml": {
-      "fgColor": "Text",
-      "layer": 2
+      "foregroundColor": "Text"
     }
   },
   "palette": {

--- a/themes/catppuccin-mocha.json
+++ b/themes/catppuccin-mocha.json
@@ -139,10 +139,10 @@
     "toggleButton.off.border.disabled": "Transparent",
 
     "iconButton.on.focusBorder": "Transparent",
-    "iconButton.on.background.default": "Transparent",
-    "iconButton.on.background.disabled": "Transparent",
-    "iconButton.on.background.hovered": "Surface0",
-    "iconButton.on.background.pressed": "Surface0",
+    "iconButton.on.background.default": "Surface0",
+    "iconButton.on.background.disabled": "Surface0",
+    "iconButton.on.background.hovered": "Surface1",
+    "iconButton.on.background.pressed": "Surface1",
     "iconButton.on.text.default": "Text",
     "iconButton.on.text.hovered": "Text",
     "iconButton.on.text.pressed": "Text",
@@ -454,151 +454,116 @@
     "ai.error.border": "Red",
     "ai.error.fill": "Transparent"
   },
-  "text-attributes": {
+  "textAttributes": {
     "attributeName.html": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "attributeValue.html": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "boolean": {
-      "fgColor": "Mauve",
-      "layer": 10
+      "foregroundColor": "Mauve"
     },
     "comment": {
-      "fgColor": "Overlay0",
-      "layer": 5
+      "foregroundColor": "Overlay0"
     },
     "comment.doc": {
-      "fgColor": "Overlay0",
-      "layer": 6
+      "foregroundColor": "Overlay0"
     },
     "comment.doc.value": {
-      "fgColor": "Overlay1",
-      "layer": 10
+      "foregroundColor": "Overlay1"
     },
     "comment.doc.tag": {
-      "fgColor": "Maroon",
-      "layer": 10
+      "foregroundColor": "Maroon"
     },
     "comment.todo": {
-      "fgColor": "Yellow",
-      "layer": 10
+      "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "bgColor": "Blue",
-      "fullLine": true,
-      "layer": -68
+      "backgroundColor": "Blue"
     },
     "diff.added": {
-      "bgColor": "a6e3a120%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "a6e3a120%",
       "stripeColor": "a6e3a120%"
     },
     "diff.added.empty": {
-      "bgColor": "a6e3a120%",
-      "layer": -60,
+      "backgroundColor": "a6e3a120%",
       "showEmptyIntervals": true
     },
     "diff.added.withBorder": {
-      "bgColor": "a6e3a120%",
+      "backgroundColor": "a6e3a120%",
       "decoration": {
         "color": "a6e3a120%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.added.word": {
-      "bgColor": "a6e3a120%",
-      "layer": -60
+      "backgroundColor": "a6e3a120%"
     },
     "diff.conflict.withBorder": {
-      "bgColor": "f38ba830%",
+      "backgroundColor": "f38ba830%",
       "decoration": {
         "color": "Red",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -68
+      }
     },
     "diff.deleted": {
-      "bgColor": "f38ba820%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "f38ba820%",
       "stripeColor": "f38ba820%"
     },
     "diff.deleted.empty": {
-      "bgColor": "f38ba820%",
-      "layer": -60,
+      "backgroundColor": "f38ba820%",
       "showEmptyIntervals": true
     },
     "diff.deleted.withBorder": {
-      "bgColor": "f38ba820%",
+      "backgroundColor": "f38ba820%",
       "decoration": {
         "color": "f38ba820%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.deleted.word": {
-      "bgColor": "f38ba820%",
-      "layer": -60,
+      "backgroundColor": "f38ba820%",
       "showEmptyIntervals": true
     },
     "diff.modified": {
-      "bgColor": "89b4fa20%",
-      "fullLine": true,
-      "layer": -69,
+      "backgroundColor": "89b4fa20%",
       "stripeColor": "89b4fa20%"
     },
     "diff.modified.withBorder": {
-      "bgColor": "89b4fa20%",
+      "backgroundColor": "89b4fa20%",
       "decoration": {
         "color": "89b4fa20%",
         "style": "BORDER"
-      },
-      "fullLine": true,
-      "layer": -69
+      }
     },
     "diff.modified.word": {
-      "bgColor": "89b4fa20%",
-      "layer": -60
+      "backgroundColor": "89b4fa20%"
     },
     "editor.brace.match": {
-      "bgColor": "Surface1",
-      "layer": 300
+      "backgroundColor": "Surface1"
     },
     "editor.rename.current": {
       "decoration": {
         "color": "Lavender",
         "style": "BORDER"
       },
-      "layer": 100,
       "showEmptyIntervals": true
     },
     "editor.rename.entries": {
-      "bgColor": "Transparent",
-      "layer": 100,
+      "backgroundColor": "Transparent",
       "showEmptyIntervals": true,
       "stripeColor": "Surface0"
     },
     "editor.search.results": {
-      "bgColor": "89b4fa40%",
-      "layer": 100,
+      "backgroundColor": "89b4fa40%",
       "stripeColor": "Blue"
     },
     "editor.selection": {
-      "bgColor": "Surface2",
-      "layer": 2000
+      "backgroundColor": "Surface2"
     },
     "editor.selection.focused": {
-      "bgColor": "Surface1",
-      "layer": 2000
+      "backgroundColor": "Surface1"
     },
     "editor.text.composable": {
       "decoration": {
@@ -606,192 +571,156 @@
       }
     },
     "editor.text.scheme": {
-      "fgColor": "Text"
+      "foregroundColor": "Text"
     },
-    "editor.indent.guide": {
-      "fgColor": "Overlay0",
+    "editor.indentGuide": {
+      "foregroundColor": "Overlay0",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.current": {
-      "fgColor": "Overlay2",
+    "editor.indentGuide.current": {
+      "foregroundColor": "Overlay2",
       "decoration": {
         "style": "DASHED"
       }
     },
-    "editor.indent.guide.declaration": {
-      "fgColor": "Surface0"
+    "editor.indentGuide.declaration": {
+      "foregroundColor": "Surface0"
     },
-    "editor.indent.guide.declaration.current": {
-      "fgColor": "Overlay0"
+    "editor.indentGuide.declaration.current": {
+      "foregroundColor": "Overlay0"
     },
     "entityReference.html": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier": {
-      "fgColor": "Text",
-      "layer": 10
+      "foregroundColor": "Text"
     },
     "identifier.alias.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.anchor.yaml": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.constant.predefined": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "identifier.field": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.field.static": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.function.call": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.package": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.call.suspend": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.function.declaration": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.interface": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.method.static": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.methodReceiver.go": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "identifier.namedArgument": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.other": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.package.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "identifier.parameter": {
-      "fgColor": "Maroon",
-      "layer": 20
+      "foregroundColor": "Maroon"
     },
     "identifier.this": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "identifier.this.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
     "identifier.type": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.class": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.enum": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.struct": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.type.valueType": {
-      "fgColor": "Lavender",
-      "layer": 20
+      "foregroundColor": "Lavender"
     },
     "identifier.typeDeclaration.go": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeParameter": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "identifier.typeReference.go": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "identifier.underCaret": {
-      "bgColor": "Transparent",
+      "backgroundColor": "Transparent",
       "decoration": {
         "color": "Surface2",
         "style": "BORDER"
-      },
-      "layer": 1000
+      }
     },
     "identifier.variable": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "identifier.variable.mutable": {
-      "layer": 20,
       "decoration": {
         "color": "Overlay2"
       }
     },
+    "key.json": {
+      "foregroundColor": "Blue"
+    },
     "key.yaml": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "keyword": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "keyword.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "keyword.extend.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "keyword.global.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "keyword.important.css": {
-      "fgColor": "Lavender",
+      "foregroundColor": "Lavender",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "keyword.typeModifier": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "link": {},
     "link.always.visible": {
@@ -801,80 +730,65 @@
       "decoration": {
         "color": "Blue"
       },
-      "fgColor": "Sapphire",
-      "layer": 100
+      "foregroundColor": "Sapphire"
     },
     "markup.bold": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "bold": true
-      },
-      "layer": 20
+      }
     },
     "markup.code.block": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "markup.heading": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "markup.href": {
       "decoration": {},
-      "fgColor": "Rosewater",
+      "foregroundColor": "Rosewater",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "markup.italic": {
-      "fgColor": "Red",
+      "foregroundColor": "Red",
       "fontModifier": {
         "italic": true
-      },
-      "layer": 20
+      }
     },
     "metadata": {
-      "fgColor": "Yellow",
-      "layer": 25
+      "foregroundColor": "Yellow"
     },
     "metadata.structTag.key.go": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "metadata.structTag.value.go": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "number": {
-      "fgColor": "Peach",
-      "layer": 10
+      "foregroundColor": "Peach"
     },
     "number.css": {
-      "fgColor": "Peach",
-      "layer": 20
+      "foregroundColor": "Peach"
     },
     "number.unit.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "other.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "problem.deprecated": {
       "decoration": {
         "color": "Overlay2",
         "position": "THROUGH"
-      },
-      "layer": 30
+      }
     },
     "problem.error": {
       "decoration": {
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 70,
       "stripeColor": "Red"
     },
     "problem.error.badCharacter": {
@@ -882,7 +796,6 @@
         "color": "Red",
         "thickness": 2.0
       },
-      "layer": 100,
       "showEmptyIntervals": true,
       "stripeColor": "Red"
     },
@@ -891,22 +804,18 @@
         "color": "94e2d540%",
         "style": "BORDER"
       },
-      "layer": 50,
       "stripeColor": "94e2d540%"
     },
     "problem.unknown": {
-      "layer": 50
     },
     "problem.unused": {
-      "fgColor": "Overlay0",
-      "layer": 60
+      "foregroundColor": "Overlay0"
     },
     "problem.warning": {
       "decoration": {
         "color": "Yellow",
         "thickness": 2.0
       },
-      "layer": 60,
       "stripeColor": "Yellow"
     },
     "problem.warning.weak": {
@@ -914,110 +823,85 @@
         "color": "f9e2af40%",
         "thickness": 2.0
       },
-      "layer": 40,
       "stripeColor": "f9e2af40%"
     },
     "propertyName.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "propertyValue.css": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "punctuation": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.css": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator": {
-      "fgColor": "Sky",
-      "layer": 20
+      "foregroundColor": "Sky"
     },
     "punctuation.operator.merge.yaml": {
-      "fgColor": "Yellow",
-      "layer": 20
+      "foregroundColor": "Yellow"
     },
     "selector.class.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.css": {
-      "fgColor": "Red",
-      "layer": 20
+      "foregroundColor": "Red"
     },
     "selector.id.css": {
-      "fgColor": "Blue",
-      "layer": 20
+      "foregroundColor": "Blue"
     },
     "selector.pseudo.css": {
-      "fgColor": "Teal",
-      "layer": 20
+      "foregroundColor": "Teal"
     },
     "selector.tag.css": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "snippet": {
-      "bgColor": "Blue",
+      "backgroundColor": "Blue",
       "borderRadius": 4.0,
       "showEmptyIntervals": true
     },
     "string": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.binary": {
-      "fgColor": "Green",
-      "layer": 15
+      "foregroundColor": "Green"
     },
     "string.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "string.escape": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.alternative": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.escape.unicode": {
-      "fgColor": "Pink",
-      "layer": 25
+      "foregroundColor": "Pink"
     },
     "string.formatItem": {
-      "fgColor": "Peach",
-      "layer": 25
+      "foregroundColor": "Peach"
     },
     "string.regexp": {
-      "fgColor": "Green",
-      "layer": 25
+      "foregroundColor": "Green"
     },
     "tag.html": {
-      "fgColor": "Text",
-      "layer": 20
+      "foregroundColor": "Text"
     },
     "tagName.custom.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "tagName.html": {
-      "fgColor": "Mauve",
-      "layer": 20
+      "foregroundColor": "Mauve"
     },
     "transparent": {},
     "url.css": {
-      "fgColor": "Green",
-      "layer": 20
+      "foregroundColor": "Green"
     },
     "value.yaml": {
-      "fgColor": "Text",
-      "layer": 2
+      "foregroundColor": "Text"
     }
   },
   "palette": {


### PR DESCRIPTION
Changes include:
- `fgColor` -> `foregroundColor`
- `bgColor` -> `backgroundColor`
- `text-attributes` -> `textAttributes`
- Removal of `layer` as it doesnt seem to do anything anymore
- Addition of new `key.json` text attribute


It also includes a fix for `iconButton` that I didn't notice before. When selected, there would be no colour change that would differentiate it from not being selected