### PR TITLE
bugfix: Update debugging current line colour to make it more redable

### DIFF
--- a/catppuccin-theme/frontendImpl/src/jvmMain/resources/catppuccin-frappe.json
+++ b/catppuccin-theme/frontendImpl/src/jvmMain/resources/catppuccin-frappe.json
@@ -493,7 +493,7 @@
       "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "backgroundColor": "Blue"
+      "backgroundColor": "#e5c89026"
     },
     "diff.added": {
       "backgroundColor": "#586e5f"

--- a/catppuccin-theme/frontendImpl/src/jvmMain/resources/catppuccin-latte.json
+++ b/catppuccin-theme/frontendImpl/src/jvmMain/resources/catppuccin-latte.json
@@ -494,7 +494,7 @@
       "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "backgroundColor": "Blue"
+      "backgroundColor": "#df8e1d26"
     },
     "diff.added": {
       "backgroundColor": "#cce1cd"

--- a/catppuccin-theme/frontendImpl/src/jvmMain/resources/catppuccin-macchiato.json
+++ b/catppuccin-theme/frontendImpl/src/jvmMain/resources/catppuccin-macchiato.json
@@ -493,7 +493,7 @@
       "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "backgroundColor": "Blue"
+      "backgroundColor": "#eed49f26"
     },
     "diff.added": {
       "backgroundColor": "#586e5f"

--- a/catppuccin-theme/frontendImpl/src/jvmMain/resources/catppuccin-mocha.json
+++ b/catppuccin-theme/frontendImpl/src/jvmMain/resources/catppuccin-mocha.json
@@ -493,7 +493,7 @@
       "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "backgroundColor": "Blue"
+      "backgroundColor": "#f9e2af26"
     },
     "diff.added": {
       "backgroundColor": "#586e5f"

--- a/fleet.tera
+++ b/fleet.tera
@@ -530,7 +530,7 @@ and set them without the transparency value.
       "foregroundColor": "Yellow"
     },
     "debug.currentFrame": {
-      "backgroundColor": "Blue"
+      "backgroundColor": "{{ yellow | mod(opacity=0.15) | get(key="hex") }}"
     },
     "diff.added": {
       "backgroundColor": "{{ diff_green }}"


### PR DESCRIPTION
Closes #50 

Now looks like this:
![image](https://github.com/user-attachments/assets/2dc40517-3e89-4a67-939b-59956e318a28)
