### PR TITLE
chore: bump whiskers check to use ubuntu 24.04

### DIFF
--- a/.github/workflows/whiskers-check.yml
+++ b/.github/workflows/whiskers-check.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
GitHub rolled back mid-migration: https://github.com/actions/runner-images/issues/10636#issuecomment-2417303444

And whiskers is incompatible with `ubuntu-22.04` out of the box: https://github.com/catppuccin/fleet/pull/57#issuecomment-2442130848